### PR TITLE
DocuSign C# Client is blocked behind corporate proxy #88

### DIFF
--- a/sdk/src/main/csharp/DocuSign/eSign/Client/ApiClient.cs
+++ b/sdk/src/main/csharp/DocuSign/eSign/Client/ApiClient.cs
@@ -29,6 +29,20 @@ namespace DocuSign.eSign.Client
 
             RestClient = new RestClient(basePath);
         }
+        
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ApiClient" /> class.
+        /// </summary>
+        /// <param name="useDefaultCredentials">Whether or not to send the default credentials will be send along to the server.</param>
+        /// <param name="basePath">The base path.</param>
+        public ApiClient(bool useDefaultCredentials, String basePath="https://www.docusign.net/restapi")
+        {
+           if (String.IsNullOrEmpty(basePath))
+                throw new ArgumentException("basePath cannot be empty");
+
+            RestClient = new RestClient(basePath);
+            UseDefaultCredentials = useDefaultCredentials;
+        }
 
         /// <summary>
         /// Gets or sets the default API client for making HTTP calls.
@@ -49,7 +63,8 @@ namespace DocuSign.eSign.Client
             Dictionary<String, FileParameter> fileParams, Dictionary<String, String> pathParams)
         {
             var request = new RestRequest(path, method);
-   
+            
+            request.UseDefaultCredentials = UseDefaultCredentials;
             // add path parameter, if any
             foreach(var param in pathParams)
                 request.AddParameter(param.Key, param.Value, ParameterType.UrlSegment); 
@@ -125,6 +140,8 @@ namespace DocuSign.eSign.Client
             return (Object)response;
         }
     
+        public bool UseDefaultCredentials {get; set; } 
+        
         /// <summary>
         /// Escape string (url-encoded).
         /// </summary>


### PR DESCRIPTION
Provided a fix for DocuSign C# Client is blocked behind corporate proxy #88.

All the tests have been executed before and after the changes were made with the same result.

Here is the issue description:
When I am using the DocuSign C# Client behind a corporate proxy the RestClient (RestSharp) instance cannot authenticate itself to the proxy server and the requests to DocuSign are being blocked.
One way to resolve this is to set the UseDefaultCredentials attribute of the RestClient instance to true. However, this property is not publicly exposed in the DocuSign C# Client SDK and the default value is "false", which makes the Nuget Package unusable for this purpose.

The UseDefaultCredentials property enables the user account credentials to be sent along to the server ( the proxy server.) The user account is the account under which the DoCuSign Client process is running.
