### PR TITLE
System.Security.Cryptography.CryptographicException: The system cannot find the file specified.

### DIFF
--- a/sdk/src/DocuSign.eSign/Client/ApiClient.cs
+++ b/sdk/src/DocuSign.eSign/Client/ApiClient.cs
@@ -626,15 +626,18 @@ namespace DocuSign.eSign.Client
 
             object result = pemReader.ReadObject();
 
+            CspParameters cspParams = new CspParameters();
+            cspParams.Flags = CspProviderFlags.UseMachineKeyStore;
+
             if (result is AsymmetricCipherKeyPair)
             {
                 AsymmetricCipherKeyPair keyPair = (AsymmetricCipherKeyPair)result;
-                return DotNetUtilities.ToRSA((RsaPrivateCrtKeyParameters)keyPair.Private);
+                return DotNetUtilities.ToRSA((RsaPrivateCrtKeyParameters)keyPair.Private, cspParams);
             }
             else if (result is RsaKeyParameters)
             {
                 RsaKeyParameters keyParameters = (RsaKeyParameters)result;
-                return DotNetUtilities.ToRSA(keyParameters);
+                return DotNetUtilities.ToRSA(keyParameters, cspParams);
             }
 
             throw new Exception("Unepxected PEM type");


### PR DESCRIPTION
In some IIS configurations, the process privilege will not have access to personal certificate store and this will throw an exception. Use the machine store instead.

=> CspProviderFlags.UseMachineKeyStore

See below for further information.
https://blogs.msdn.microsoft.com/winsdk/2009/11/16/opps-system-security-cryptography-cryptographicexception-the-system-cannot-find-the-file-specified/