### PR TITLE
Using Machine Key Store when creating RSA provider

### DIFF
--- a/sdk/.gitignore
+++ b/sdk/.gitignore
@@ -53,6 +53,8 @@ build/
 *.log
 *.scc
 
+.vs/
+
 # OS generated files #
 .DS_Store*
 ehthumbs.db


### PR DESCRIPTION
This fixes an issue when deploying to Azure Web Apps where the app pool does not have enough permissions to access the default key store.