### PR TITLE
4.4.1GA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 ﻿# DocuSign C# Client Changelog
 
+## [v4.4.1] - eSignature API v2.1-20.1.02 - 05/29/2020
+### Changed
+*   Added support for version v2.1-20.1.02 of the DocuSign eSignature API.
+*   Updated the SDK release version
+### Added
+*   Made InterceptRequest and InterceptResponse methods overriable (DCM-4242)
+
+
 ## [v4.4.0-rc] - eSignature API v2.1-20.1.02 - 05/14/2020
 ### Changed
 *   Added support for version v2.1-20.1.02 of the DocuSign eSignature API.

--- a/sdk/src/DocuSign.eSign/Client/ApiClient.cs
+++ b/sdk/src/DocuSign.eSign/Client/ApiClient.cs
@@ -59,14 +59,20 @@ namespace DocuSign.eSign.Client
         /// Allows for extending request processing for <see cref="ApiClient"/> generated code.
         /// </summary>
         /// <param name="request">The RestSharp request object</param>
-        partial void InterceptRequest(IRestRequest request);
+        public virtual void InterceptRequest(IRestRequest request)
+        {
+            //Override this to add telemetry
+        }
 
         /// <summary>
         /// Allows for extending response processing for <see cref="ApiClient"/> generated code.
         /// </summary>
         /// <param name="request">The RestSharp request object</param>
         /// <param name="response">The RestSharp response object</param>
-        partial void InterceptResponse(IRestRequest request, IRestResponse response);
+        public virtual void InterceptResponse(IRestRequest request, IRestResponse response)
+        {
+            //Override this to add telemetry
+        }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ApiClient" /> class

--- a/sdk/src/DocuSign.eSign/Client/Configuration.cs
+++ b/sdk/src/DocuSign.eSign/Client/Configuration.cs
@@ -47,7 +47,7 @@ namespace DocuSign.eSign.Client
                              string tempFolderPath = null,
                              string dateTimeFormat = null,
                              int timeout = 100000,
-                             string userAgent = "Swagger-Codegen/4.4.0-rc/csharp"
+                             string userAgent = "Swagger-Codegen/4.4.1/csharp"
                             )
         {
             setApiClientUsingDefault(apiClient);
@@ -82,7 +82,7 @@ namespace DocuSign.eSign.Client
         /// Version of the package.
         /// </summary>
         /// <value>Version of the package.</value>
-        public const string Version = "4.4.0-rc";
+        public const string Version = "4.4.1";
 
         /// <summary>
         /// Gets or sets the default Configuration.
@@ -344,7 +344,7 @@ namespace DocuSign.eSign.Client
                      .GetReferencedAssemblies()
                      .Where(x => x.Name == "System.Core").First().Version.ToString() + "\n";
             report += "    Version of the API: v2.1\n";
-            report += "    SDK Package Version: 4.4.0-rc\n";
+            report += "    SDK Package Version: 4.4.1\n";
 
             return report;
         }

--- a/sdk/src/DocuSign.eSign/DocuSign.eSign.csproj
+++ b/sdk/src/DocuSign.eSign/DocuSign.eSign.csproj
@@ -24,17 +24,17 @@ Contact: devcenter@docusign.com
     <RootNamespace>DocuSign.eSign</RootNamespace>
     <AssemblyName>DocuSign.eSign</AssemblyName>
     <NeutralLanguage>en-US</NeutralLanguage>
-    <VersionPrefix>4.4.0-rc</VersionPrefix>
+    <VersionPrefix>4.4.1</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageTags>DocuSign.eSign;REST;eSign;docusign;eSignature;api</PackageTags>
-    <PackageIconUrl>https://docucdn-a.akamaihd.net/olive/images/2.17.0/favicons/favicon-32x32.png</PackageIconUrl>
+    <PackageIconUrl>https://s.gravatar.com/avatar/4a8c033df6baa902f730d514d5574c33</PackageIconUrl>
     <PackageProjectUrl>https://github.com/docusign/docusign-csharp-client</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/docusign/docusign-csharp-client/blob/master/LICENSE</PackageLicenseUrl>
     <RepositoryUrl>https://github.com/docusign/docusign-csharp-client</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
-    <PackageReleaseNotes>[v4.4.0-rc] - eSignature API v2.1-20.1.02 - 05/14/2020</PackageReleaseNotes>
+    <PackageReleaseNotes>[v4.4.1] - eSignature API v2.1-20.1.02 - 05/29/2020</PackageReleaseNotes>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/sdk/src/DocuSign.eSign/DocuSign.eSign.nuspec
+++ b/sdk/src/DocuSign.eSign/DocuSign.eSign.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>DocuSign.eSign.dll</id>
-    <version>4.4.0-rc</version>
+    <version>4.4.1</version>
     <title>DocuSign.eSign</title>
     <authors>DocuSign</authors>
     <owners>DocuSign</owners>

--- a/sdk/src/DocuSign.eSign/Properties/AssemblyInfo.cs
+++ b/sdk/src/DocuSign.eSign/Properties/AssemblyInfo.cs
@@ -22,5 +22,5 @@ using System.Runtime.InteropServices;
 // [assembly: AssemblyVersion("1.0.*")]
 internal class AssemblyInformation
 {
-    public const string AssemblyInformationalVersion = "4.4.0-rc";
+    public const string AssemblyInformationalVersion = "4.4.1";
 }

--- a/test/SdkNetCoreTests/SdkNetCoreTests.csproj
+++ b/test/SdkNetCoreTests/SdkNetCoreTests.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="DocuSign.eSign.dll" Version="4.4.0-rc" />
+    <PackageReference Include="DocuSign.eSign.dll" Version="4.4.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.2.1" />
     <PackageReference Include="MSTest.TestFramework" Version="1.2.1" />
@@ -22,11 +22,5 @@
     <PackageReference Include="Microsoft.IdentityModel.Protocols" Version="5.4.0" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="5.4.0" />
   </ItemGroup>
-
-  <ItemGroup>
-    <Reference Include="DocuSign.eSign">
-      <HintPath>..\..\sdk\src\DocuSign.eSign\bin\Debug\netstandard2.0\DocuSign.eSign.dll</HintPath>
-    </Reference>
-  </ItemGroup>
-
+  
 </Project>

--- a/test/SdkTests462/SdkTests462.csproj
+++ b/test/SdkTests462/SdkTests462.csproj
@@ -43,8 +43,8 @@
     <Reference Include="BouncyCastle.Crypto, Version=1.8.1.0, Culture=neutral, PublicKeyToken=0e99375e54769942">
       <HintPath>..\packages\BouncyCastle.1.8.1\lib\BouncyCastle.Crypto.dll</HintPath>
     </Reference>
-    <Reference Include="DocuSign.eSign, Version=4.4.0.0, Culture=neutral, PublicKeyToken=7fca6fcbbc219ede, processorArchitecture=MSIL">
-      <HintPath>..\packages\DocuSign.eSign.dll.4.4.0-rc\lib\net452\DocuSign.eSign.dll</HintPath>
+    <Reference Include="DocuSign.eSign, Version=4.4.1.0, Culture=neutral, PublicKeyToken=7fca6fcbbc219ede, processorArchitecture=MSIL">
+      <HintPath>..\packages\DocuSign.eSign.dll.4.4.1\lib\net452\DocuSign.eSign.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Microsoft.IdentityModel.JsonWebTokens, Version=5.4.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">

--- a/test/SdkTests462/packages.config
+++ b/test/SdkTests462/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="BouncyCastle" version="1.8.1" targetFramework="net462" />
-  <package id="DocuSign.eSign.dll" version="4.4.0-rc" targetFramework="net462" />
+  <package id="DocuSign.eSign.dll" version="4.4.1" targetFramework="net462" />
   <package id="Microsoft.CSharp" version="4.5.0" targetFramework="net462" />
   <package id="Microsoft.IdentityModel.JsonWebTokens" version="5.4.0" targetFramework="net462" />
   <package id="Microsoft.IdentityModel.Logging" version="5.4.0" targetFramework="net462" />


### PR DESCRIPTION
## [v4.4.1] - eSignature API v2.1-20.1.02 - 05/29/2020
### Changed
*   Added support for version v2.1-20.1.02 of the DocuSign eSignature API.
*   Updated the SDK release version
### Added
*   Made InterceptRequest and InterceptResponse methods overriable (DCM-4242)