### PR TITLE
v2-3.7.0GA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 ﻿# DocuSign C# Client Changelog - eSignature API v2
 
+## [v3.7.0] - eSignature API v2-20.3.00 - 10/01/2020
+### Changed
+*   Added support for version v2-20.3.00 of the DocuSign eSignature API.
+*   Updated the SDK release version
+### Fixed
+*	A bug with ApiClient SetBasePath which did not update basePath for RestClient (DCM-4276).
+
 ## [v3.7.0-rc] - eSignature API v2-20.3.00 - 09/24/2020
 ### Changed
 *   Added support for version v2-20.3.00 of the DocuSign eSignature API.

--- a/sdk/src/DocuSign.eSign/Client/Configuration.cs
+++ b/sdk/src/DocuSign.eSign/Client/Configuration.cs
@@ -26,7 +26,7 @@ namespace DocuSign.eSign.Client
         /// Version of the package.
         /// </summary>
         /// <value>Version of the package.</value>
-        public const string Version = "3.7.0-rc";
+        public const string Version = "3.7.0";
 
         /// <summary>
         /// Identifier for ISO 8601 DateTime Format

--- a/sdk/src/DocuSign.eSign/DocuSign.eSign.csproj
+++ b/sdk/src/DocuSign.eSign/DocuSign.eSign.csproj
@@ -24,7 +24,7 @@ Contact: devcenter@docusign.com
     <RootNamespace>DocuSign.eSign</RootNamespace>
     <AssemblyName>DocuSign.eSign</AssemblyName>
     <NeutralLanguage>en-US</NeutralLanguage>
-    <VersionPrefix>3.7.0-rc</VersionPrefix>
+    <VersionPrefix>3.7.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
@@ -34,7 +34,7 @@ Contact: devcenter@docusign.com
     <PackageLicenseUrl>https://github.com/docusign/docusign-csharp-client/blob/master/LICENSE</PackageLicenseUrl>
     <RepositoryUrl>https://github.com/docusign/docusign-csharp-client</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
-    <PackageReleaseNotes>[3.7.0-rc] - eSignature API v2-20.2.03.00 - 09/24/2020 </PackageReleaseNotes>
+    <PackageReleaseNotes>[3.7.0] - eSignature API v2-20.2.03.00 - 10/01/2020 </PackageReleaseNotes>
   </PropertyGroup>
 
   <!-- .NET Framework 4.5.2 compilation flags and build options -->

--- a/sdk/src/DocuSign.eSign/DocuSign.eSign.nuspec
+++ b/sdk/src/DocuSign.eSign/DocuSign.eSign.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>DocuSign.eSign.dll</id>
-    <version>3.7.0-rc</version>
+    <version>3.7.0</version>
     <title>DocuSign.eSign</title>
     <authors>DocuSign</authors>
     <owners>DocuSign</owners>

--- a/sdk/src/DocuSign.eSign/Properties/AssemblyInfo.cs
+++ b/sdk/src/DocuSign.eSign/Properties/AssemblyInfo.cs
@@ -22,5 +22,5 @@ using System.Runtime.InteropServices;
 // [assembly: AssemblyVersion("1.0.*")]
 internal class AssemblyInformation
 {
-    public const string AssemblyInformationalVersion = "3.7.0-rc";
+    public const string AssemblyInformationalVersion = "3.7.0";
 }


### PR DESCRIPTION
## [v3.7.0] - eSignature API v2-20.3.00 - 10/01/2020
### Changed
*   Added support for version v2-20.3.00 of the DocuSign eSignature API.
*   Updated the SDK release version
### Fixed
*	A bug with ApiClient SetBasePath which did not update basePath for RestClient (DCM-4276).